### PR TITLE
get trials of type image keyboard response

### DIFF
--- a/static/js/experiment.js
+++ b/static/js/experiment.js
@@ -127,7 +127,7 @@ async function initializeExperiment() {
 
   function getAverageResponseTime() {
 
-    var trials = jsPsych.data.getTrialsOfType('html-keyboard-response');
+    var trials = jsPsych.data.get().filter({trial_type: 'image-keyboard-response'}).values();
 
     var sum_rt = 0;
     var valid_trial_count = 0;


### PR DESCRIPTION
1. getTrialsOfType() has been deprecated I believe
2. should be image-keyboard-response, not html-keyboard-response